### PR TITLE
Don't mutate in place

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ npm install object-property-assigner
 
 ## Usage
 
+*Note: function returns a shallow copy of the input, the original object is unmodified*
+
 `assign( dataObject, propertyString, newValue, { options } )`
 (See below for [`options` details](#options))
 
@@ -57,9 +59,9 @@ npm install object-property-assigner
 import assign from "object-property-assigner"
 
 // Using the data object above
-assign(data, "user.name.first", "Boba") // data.user.name.first = "Boba"
+data = assign(data, "user.name.first", "Boba") // data.user.name.first = "Boba"
 
-assign(data, "user.weapons[1].description", "Pew Pew") // data.user.weapons[1].description = "Pew Pew"
+data = assign(data, "user.weapons[1].description", "Pew Pew") // data.user.weapons[1].description = "Pew Pew"
 ```
 
 ### Array handling
@@ -68,9 +70,10 @@ In addition to accessing array by index (above), if an array consists of objects
 
 For example:
 ```js
-assign(data, "user.weapons.name", "Laser Gun")
+data = assign(data, "user.weapons.name", "Laser Gun")
 // sets *all* user.weapons.name to "Laser Gun"
 ```
+
 
 ### Options
 
@@ -84,7 +87,12 @@ The (optional) `options` object can contain any or all of the following paramete
   ```js
   assign(data, "user.kind", "Mandalorian", {createNew: true}) // data.user.kind = "Mandalorian"
   ```  
-- `noError` -- (default: `false`). If a property doesn't exist *and* `createNew == false`, then an error will be thrown. If you'd rather it just silently ignored the missing property, then set this parameter to `true`. Note that this is only for errors due to invalid property strings -- other errors might still be thrown
+  Note: for arrays, if an index is specified higher than the current array length, a new item will be created as the *next* array item, regardless of how much higher the index is. e.g.  
+  ```js
+  assign( {myArray: [1, 2, 3]}, "myArray[10]", "New Value")
+  // --> {myArray: [1, 2, 3, "New Value"]}
+  ```
+- `noError` -- (default: `false`). If a property doesn't exist *and* `createNew == false`, then an error will be thrown. If you'd rather it just silently ignored the missing property, then set this parameter to `true`. Note that this is only for errors due to invalid property strings -- other errors might still be thrown.
 
 ## Testing
 

--- a/src/assign.ts
+++ b/src/assign.ts
@@ -9,6 +9,7 @@ import {
 } from './helpers'
 import { FullOptions, Input, InputArray, InputObject, Options, Path } from './types'
 
+// Wrapper function
 const assign = (data: Input, propertyPath: string | Path, newValue: any, options: Options = {}) => {
   const { remove = false, createNew = true, noError = false } = options
   const fullData = data
@@ -18,18 +19,16 @@ const assign = (data: Input, propertyPath: string | Path, newValue: any, options
   const propertyPathArray = splitPropertyString(propertyPath).filter((e) => e !== '')
 
   if (isArray(data) && remove && propertyPathArray.length === 1) {
-    // Special case for removing an array index that is at the top level. We'd
+    // Special case for removing an array index that is at the root level. We'd
     // normally have to do this from the parent (see below), but that's not
     // possible here.
     return removeFromArray(data, propertyPathArray[0] as number)
   }
 
-  const newData = assignProperty(data, propertyPathArray, newValue, fullOptions)
-  return newData
+  return assignProperty(data, propertyPathArray, newValue, fullOptions)
 }
 
-// Assigns a specific property or index (e.g. application.name) inside a nested
-// Object
+// Recursive function called by wrapper
 const assignProperty = (
   data: Input,
   propertyPathArray: Path,

--- a/src/assign.ts
+++ b/src/assign.ts
@@ -24,63 +24,62 @@ const assign = (data: Input, propertyPath: string | Path, newValue: any, options
     return removeFromArray(data, propertyPathArray[0] as number)
   }
 
-  assignProperty(data, propertyPathArray, newValue, fullOptions)
-  return data
+  const newData = assignProperty(data, propertyPathArray, newValue, fullOptions)
+  return newData
 }
 
 // Assigns a specific property or index (e.g. application.name) inside a nested
-// Object -- modifies "data" in-place
+// Object
 const assignProperty = (
   data: Input,
   propertyPathArray: Path,
   newValue: any,
   options: FullOptions
-) => {
-  const dataIsObject = isObject(data)
-  const dataIsArray = isArray(data)
+): Input => {
+  const objectData = isObject(data) ? { ...data } : null
+  const arrayData = isArray(data) ? [...data] : null
 
   // Do nothing for empty property string
-  if (propertyPathArray.length === 0) return
+  if (propertyPathArray.length === 0) return data
 
-  if (!(dataIsObject || dataIsArray))
-    throw new Error("Can't assign property -- invalid input object")
+  if (!(objectData || arrayData)) throw new Error("Can't assign property -- invalid input object")
 
   const { createNew, remove, noError, fullData, fullPath } = options
 
   const property = propertyPathArray[0]
 
-  if (dataIsArray && typeof property === 'string') {
-    data.forEach((item) => assignProperty(item as Input, propertyPathArray, newValue, options))
-    return
+  if (arrayData && typeof property === 'string') {
+    return arrayData.map((item) =>
+      assignProperty(item as Input, propertyPathArray, newValue, options)
+    )
   }
 
   // BASE
   if (propertyPathArray.length === 1) {
-    if (dataIsObject && typeof property === 'string') {
-      updateObject(data, property, newValue, options)
-      return
+    if (objectData && typeof property === 'string') {
+      updateObject(objectData, property, newValue, options)
+      return objectData
     }
 
-    if (dataIsArray && typeof property === 'number') {
-      updateArray(data, property, newValue, options)
-      return
+    if (arrayData && typeof property === 'number') {
+      updateArray(arrayData, property, newValue, options)
+      return arrayData
     }
 
     maybeThrow(fullData, fullPath, property, noError)
-    return
+    return data
   }
 
   // RECURSIVE
-
-  const dataObject = data as InputObject
+  const newData = (objectData || arrayData || []) as InputObject
 
   if (remove && propertyPathArray.length === 2 && typeof propertyPathArray[1] === 'number') {
     // This is for removing an indexed element from an array -- it must
     // be done from the parent, as an array can't have an element removed
-    // in-place, so we need to return a shallow copy of the filtered array
-    const childArray = dataObject[property]
+    // in-place, so we need to return a copy of the filtered array
+    const childArray = newData[property]
     const childArrayIndex = propertyPathArray[1]
-    if (isArray(childArray)) dataObject[property] = removeFromArray(childArray, childArrayIndex)
+    if (isArray(childArray)) newData[property] = removeFromArray(childArray, childArrayIndex)
     else
       maybeThrow(
         fullData,
@@ -89,7 +88,7 @@ const assignProperty = (
         noError,
         `Trying to remove an indexed item from an object that is not an array`
       )
-    return
+    return newData
   }
 
   const newPathArray = propertyPathArray.slice(1)
@@ -97,25 +96,48 @@ const assignProperty = (
   if (property in data) {
     // This is for the case where the current property exists, but it's not an
     // object, so subsequent path elements can't be added
-    if (isPrimitive(dataObject[property])) {
-      if (createNew) dataObject[property] = {}
-      else return
+    if (isPrimitive(newData[property])) {
+      if (createNew) newData[property] = {}
+      else {
+        maybeThrow(fullData, fullPath, property, noError)
+        return newData
+      }
     }
+    newData[property] = assignProperty(newData[property] as Input, newPathArray, newValue, options)
 
-    const newData = dataObject[property] as Input
-
-    assignProperty(newData, newPathArray, newValue, options)
-    return
+    return newData
   }
 
-  if (dataIsObject && createNew) {
-    data[property] = {}
-    const newData = data[property] as Input
-    assignProperty(newData, newPathArray, newValue, options)
-    return
+  if (createNew) {
+    const nextPathElement = newPathArray[0]
+    const newElement = typeof nextPathElement === 'number' ? [] : {}
+
+    if (objectData) {
+      newData[property] = newElement
+      newData[property] = assignProperty(
+        newData[property] as Input,
+        newPathArray,
+        newValue,
+        options
+      )
+      return newData
+    }
+
+    if (arrayData && Array.isArray(newData)) {
+      newData.push(newElement)
+      const newIndex = newData.length - 1
+      newData[newIndex] = assignProperty(
+        newData[newIndex] as Input,
+        newPathArray,
+        newValue,
+        options
+      )
+      return newData
+    }
   }
 
   maybeThrow(fullData, fullPath, property, noError)
+  return newData
 }
 
 // Actual mutations of the leaf nodes, which considers all options and cases
@@ -139,10 +161,11 @@ const updateObject = (data: InputObject, property: string, newValue: any, option
 }
 
 const updateArray = (data: InputArray, property: number, newValue: any, options: FullOptions) => {
-  const { noError, fullData, fullPath } = options
+  const { noError, fullData, fullPath, createNew } = options
 
   if (!(property in data)) {
-    maybeThrow(fullData, fullPath, property, noError)
+    if (createNew) data.push(newValue)
+    else maybeThrow(fullData, fullPath, property, noError)
     return
   }
 

--- a/src/dev/dev.ts
+++ b/src/dev/dev.ts
@@ -32,40 +32,12 @@ const arrayObj = [
   },
 ]
 
-const data = {
+const arrayNestedEarly = {
   list: [
-    {
-      sterility: {
-        value: {
-          text: 'Non-sterile',
-          selection: 'Non-sterile',
-          optionIndex: 1,
-        },
-        isValid: true,
-        stageNumber: 1,
-        evaluatedParameters: {
-          label: 'Sterility',
-          options: ['Sterile', 'Non-sterile'],
-        },
-      },
-    },
-    {
-      sterility: {
-        value: {
-          text: 'Another',
-          selection: 'Non-sterile',
-          optionIndex: 1,
-        },
-        isValid: true,
-        stageNumber: 1,
-        evaluatedParameters: {
-          label: 'Sterility',
-          options: ['Sterile', 'Non-sterile'],
-        },
-      },
-    },
+    { one: 1, value: { text: 'Number 1' }, three: [1, 2, 3] },
+    { one: 2, value: { text: 'Number 2' }, three: [4, 5, 6] },
+    { one: 3, value: { text: 'Number 3' }, three: [7, 8, 9] },
   ],
-  text: 'Sterility: Non-sterile, Dosage Form: Solid Unit Dosage Forms, \n',
 }
 
 const arrayDoubleNested = {
@@ -91,12 +63,10 @@ const arrayDoubleNested = {
   ],
 }
 
-const smallerObj = { a: 1, two: { three: 3 } }
-
-const testObj2: any = { ...testObj1 }
-delete testObj2.fun
+const smallerObj = { two: { three: 3 }, a: 1 }
 
 const simpleArray = [0, 1, 2, 3]
 
-const x = assign(simpleArray, '[1]', null, { remove: true })
+const x = assign(testObj1, 'b.inner3.innerArray[2][2]', 'ADD THIS')
+// console.log(JSON.stringify(testObj1, null, 2))
 console.log(JSON.stringify(x, null, 2))

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,14 +1,18 @@
-import { BasicType, InputObject, Value } from './types'
+import { BasicType, InputObject, Path, Value } from './types'
 
 // Splits a string representing a (nested) property/index on an Object or Array
 // into array of strings/indexes
 // e.g. "data.organisations.nodes[0]" => ["data","organisations", "nodes", 0]
-export const splitPropertyString = (propertyPath: string | (string | number)[]) => {
+export const splitPropertyString = (propertyPath: string | Path) => {
   if (Array.isArray(propertyPath)) return propertyPath
-  const arr = propertyPath.split('.').map((part) => {
-    const match = /(.*)\[(\d)\]$/.exec(part)
-    return !match ? part : [match[1], Number(match[2])].filter((val) => val !== '')
-  })
+  const arr = propertyPath
+    .split(/(\.|\[\d+\])/)
+    .filter((part) => part !== '.' && part !== '')
+    .map((part) => {
+      const match = /\[(\d+)\]/.exec(part)
+      if (!match) return part
+      return Number(match[1])
+    })
   return arr.flat()
 }
 

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -21,9 +21,12 @@ const testObj1: any = {
   ee: [1, 'two', { three: 4 }, false, undefined, null],
   fun: (n: number) => n * 2,
 }
+const testObj1_original = cloneDeep(testObj1)
 
 const testObj2 = { ...testObj1 }
 delete testObj2.fun
+
+const testObj2_original = cloneDeep(testObj2)
 
 const arrayObj = [
   1,
@@ -36,6 +39,8 @@ const arrayObj = [
   },
 ]
 
+const arrayObj_original = cloneDeep(arrayObj)
+
 const arrayNestedEarly = {
   list: [
     { one: 1, value: { text: 'Number 1' }, three: [1, 2, 3] },
@@ -43,6 +48,8 @@ const arrayNestedEarly = {
     { one: 3, value: { text: 'Number 3' }, three: [7, 8, 9] },
   ],
 }
+
+const arrayNestedEarly_original = cloneDeep(arrayNestedEarly)
 
 const arrayDoubleNested = {
   list: [
@@ -67,79 +74,112 @@ const arrayDoubleNested = {
   ],
 }
 
+const arrayDoubleNested_original = cloneDeep(arrayDoubleNested)
+
 // Base level properties
 test('Base props 1', () => {
-  expect(assign(cloneDeep(testObj1), 'a', 'ten')).toStrictEqual({
-    ...testObj1,
+  expect(assign(testObj1, 'a', 'ten')).toStrictEqual({
+    ...testObj1_original,
     a: 'ten',
   })
+  // Check stringified to ensure key order has been preserved
+  expect(assign(testObj1, 'a', 'ten')).toEqual({
+    ...testObj1_original,
+    a: 'ten',
+  })
+  // Ensure original hasn't been modified
+  expect(testObj1).toStrictEqual(testObj1_original)
 })
 
 test('Base props 2', () => {
-  expect(assign(cloneDeep(testObj1), 'cee', 'something')).toStrictEqual({
-    ...testObj1,
+  expect(assign(testObj1, 'cee', 'something')).toStrictEqual({
+    ...testObj1_original,
     cee: 'something',
   })
+  // Ensure original hasn't been modified
+  expect(testObj1).toStrictEqual(testObj1_original)
 })
 
 // Deep objects, various types
 test('Deep props 1', () => {
-  expect(assign(cloneDeep(testObj1), 'b.inner', 'that')).toStrictEqual({
-    ...testObj1,
-    b: { ...testObj1.b, inner: 'that' },
+  expect(assign(testObj1, 'b.inner', 'that')).toStrictEqual({
+    ...testObj1_original,
+    b: { ...testObj1_original.b, inner: 'that' },
   })
+  // Ensure original hasn't been modified
+  expect(testObj1).toStrictEqual(testObj1_original)
 })
 
 test('Deep props 2', () => {
-  expect(assign(cloneDeep(testObj1), 'b.inner3.innerDeep', null)).toStrictEqual({
-    ...testObj1,
-    b: { ...testObj1.b, inner3: { ...testObj1.b.inner3, innerDeep: null } },
+  expect(assign(testObj1, 'b.inner3.innerDeep', null)).toStrictEqual({
+    ...testObj1_original,
+    b: { ...testObj1_original.b, inner3: { ...testObj1_original.b.inner3, innerDeep: null } },
   })
+  // Ensure original hasn't been modified
+  expect(testObj1).toStrictEqual(testObj1_original)
 })
 
 test('Get inner object, deeper', () => {
-  expect(assign(cloneDeep(testObj1), 'b.inner3', { new: 'Hi', val: 'There' })).toStrictEqual({
-    ...testObj1,
-    b: { ...testObj1.b, inner3: { new: 'Hi', val: 'There' } },
+  expect(assign(testObj1, 'b.inner3', { new: 'Hi', val: 'There' })).toStrictEqual({
+    ...testObj1_original,
+    b: { ...testObj1_original.b, inner3: { new: 'Hi', val: 'There' } },
   })
+  // Ensure original hasn't been modified
+  expect(testObj1).toStrictEqual(testObj1_original)
 })
 
 // Get arrays, various depths
 test('Array at top level', () => {
-  expect(assign(cloneDeep(testObj1), 'ee', ['new', 'array'])).toStrictEqual({
-    ...testObj1,
+  expect(assign(testObj1, 'ee', ['new', 'array'])).toStrictEqual({
+    ...testObj1_original,
     ee: ['new', 'array'],
   })
+  // Ensure original hasn't been modified
+  expect(testObj1).toStrictEqual(testObj1_original)
 })
 
 test('Array inner', () => {
-  expect(assign(cloneDeep(testObj1), 'b.inner3.innerArray', 'plain string')).toStrictEqual({
-    ...testObj1,
-    b: { ...testObj1.b, inner3: { ...testObj1.b.inner3, innerArray: 'plain string' } },
-  })
+  expect(JSON.stringify(assign(testObj1, 'b.inner3.innerArray', 'plain string'))).toStrictEqual(
+    JSON.stringify({
+      ...testObj1_original,
+      b: {
+        ...testObj1_original.b,
+        inner3: { ...testObj1_original.b.inner3, innerArray: 'plain string' },
+      },
+    })
+  )
+  // Ensure original hasn't been modified
+  expect(testObj1).toStrictEqual(testObj1_original)
 })
 
 test('Assign array by index', () => {
-  expect(assign(cloneDeep(testObj1), 'ee[1]', 'No longer two')).toStrictEqual({
-    ...testObj1,
+  expect(assign(testObj1, 'ee[1]', 'No longer two')).toStrictEqual({
+    ...testObj1_original,
     ee: [1, 'No longer two', { three: 4 }, false, undefined, null],
   })
+  // Ensure original hasn't been modified
+  expect(testObj1).toStrictEqual(testObj1_original)
 })
 
 test('Assign array by index - deeper', () => {
-  expect(assign(cloneDeep(testObj1), 'b.inner3.innerDeep2[2]', undefined)).toStrictEqual({
-    ...testObj1,
-    b: { ...testObj1.b, inner3: { ...testObj1.b.inner3, innerDeep2: [1, 2, undefined] } },
+  expect(assign(testObj1, 'b.inner3.innerDeep2[2]', undefined)).toStrictEqual({
+    ...testObj1_original,
+    b: {
+      ...testObj1_original.b,
+      inner3: { ...testObj1_original.b.inner3, innerDeep2: [1, 2, undefined] },
+    },
   })
+  // Ensure original hasn't been modified
+  expect(testObj1).toStrictEqual(testObj1_original)
 })
 
 test('Assign property inside object in indexed array', () => {
-  expect(assign(cloneDeep(testObj1), 'b.inner3.innerArray[1].four', '{ one: 1 }')).toStrictEqual({
-    ...testObj1,
+  expect(assign(testObj1, 'b.inner3.innerArray[1].four', '{ one: 1 }')).toStrictEqual({
+    ...testObj1_original,
     b: {
-      ...testObj1.b,
+      ...testObj1_original.b,
       inner3: {
-        ...testObj1.b.inner3,
+        ...testObj1_original.b.inner3,
         innerArray: [
           { one: 1, two: 'two', three: true, four: null, five: true },
           { one: 'one', two: 2, three: 3, four: '{ one: 1 }' },
@@ -147,10 +187,12 @@ test('Assign property inside object in indexed array', () => {
       },
     },
   })
+  // Ensure original hasn't been modified
+  expect(testObj1).toStrictEqual(testObj1_original)
 })
 
 test('Array at top level (object is array)', () => {
-  expect(assign(cloneDeep(arrayObj), '[0]', 99)).toStrictEqual([
+  expect(assign(arrayObj, '[0]', 99)).toStrictEqual([
     99,
     2,
     {
@@ -160,10 +202,12 @@ test('Array at top level (object is array)', () => {
       ],
     },
   ])
+  // Ensure original hasn't been modified
+  expect(arrayObj).toStrictEqual(arrayObj_original)
 })
 
 test('Array at top level (object is array), with nested elements', () => {
-  expect(assign(cloneDeep(arrayObj), '[2].one.y', { more: 'yes' })).toStrictEqual([
+  expect(assign(arrayObj, '[2].one.y', { more: 'yes' })).toStrictEqual([
     1,
     2,
     {
@@ -173,40 +217,48 @@ test('Array at top level (object is array), with nested elements', () => {
       ],
     },
   ])
+  // Ensure original hasn't been modified
+  expect(arrayObj).toStrictEqual(arrayObj_original)
 })
 
 test('Target multiple array elements with array early in path', () => {
-  expect(assign(cloneDeep(arrayNestedEarly), 'list.one', 99)).toStrictEqual({
+  expect(assign(arrayNestedEarly, 'list.one', 99)).toStrictEqual({
     list: [
       { one: 99, value: { text: 'Number 1' }, three: [1, 2, 3] },
       { one: 99, value: { text: 'Number 2' }, three: [4, 5, 6] },
       { one: 99, value: { text: 'Number 3' }, three: [7, 8, 9] },
     ],
   })
+  // Ensure original hasn't been modified
+  expect(arrayNestedEarly).toStrictEqual(arrayNestedEarly_original)
 })
 
 test('Target multiple array elements with array early in path, deeper', () => {
-  expect(assign(cloneDeep(arrayNestedEarly), 'list.value.text', 'NEW WORLD')).toStrictEqual({
+  expect(assign(arrayNestedEarly, 'list.value.text', 'NEW WORLD')).toStrictEqual({
     list: [
       { one: 1, value: { text: 'NEW WORLD' }, three: [1, 2, 3] },
       { one: 2, value: { text: 'NEW WORLD' }, three: [4, 5, 6] },
       { one: 3, value: { text: 'NEW WORLD' }, three: [7, 8, 9] },
     ],
   })
+  // Ensure original hasn't been modified
+  expect(arrayNestedEarly).toStrictEqual(arrayNestedEarly_original)
 })
 
 test('Target multiple array elements with array early in path, another array deeper', () => {
-  expect(assign(cloneDeep(arrayNestedEarly), 'list.three[1]', 99)).toStrictEqual({
+  expect(assign(arrayNestedEarly, 'list.three[1]', 99)).toStrictEqual({
     list: [
       { one: 1, value: { text: 'Number 1' }, three: [1, 99, 3] },
       { one: 2, value: { text: 'Number 2' }, three: [4, 99, 6] },
       { one: 3, value: { text: 'Number 3' }, three: [7, 99, 9] },
     ],
   })
+  // Ensure original hasn't been modified
+  expect(arrayNestedEarly).toStrictEqual(arrayNestedEarly_original)
 })
 
-test('Target multiple array elements with array early in path, another array deeper', () => {
-  expect(assign(cloneDeep(arrayDoubleNested), 'list.three.name', null)).toStrictEqual({
+test('Doubly nested array, without indexes (i.e. update every element in arrays', () => {
+  expect(assign(arrayDoubleNested, 'list.three.name', null)).toStrictEqual({
     list: [
       {
         one: 1,
@@ -228,17 +280,21 @@ test('Target multiple array elements with array early in path, another array dee
       { one: 3, value: { text: 'Number 3' }, three: [{ name: null, height: 1.5 }] },
     ],
   })
+  // Ensure original hasn't been modified
+  expect(arrayDoubleNested).toStrictEqual(arrayDoubleNested_original)
 })
 
 test('Ignore irrelevant trailing characters in property string', () => {
-  expect(assign(cloneDeep(testObj1), 'ee[0].', 'NEW')).toStrictEqual({
-    ...testObj1,
+  expect(assign(testObj1, 'ee[0].', 'NEW')).toStrictEqual({
+    ...testObj1_original,
     ee: ['NEW', 'two', { three: 4 }, false, undefined, null],
   })
+  // Ensure original hasn't been modified
+  expect(testObj1).toStrictEqual(testObj1_original)
 })
 
 test('Ignore irrelevant trailing characters in property string, array top-level', () => {
-  expect(assign(cloneDeep(arrayObj), '[0].', 'Bob')).toStrictEqual([
+  expect(assign(arrayObj, '[0].', 'Bob')).toStrictEqual([
     'Bob',
     2,
     {
@@ -248,55 +304,63 @@ test('Ignore irrelevant trailing characters in property string, array top-level'
       ],
     },
   ])
+  // Ensure original hasn't been modified
+  expect(arrayObj).toStrictEqual(arrayObj_original)
 })
 
 test('Throw error with missing final property', () => {
-  expect(() =>
-    assign(cloneDeep(testObj1), 'b.inner3.missing', 'NEW', { createNew: false })
-  ).toThrow(
+  expect(() => assign(testObj1, 'b.inner3.missing', 'NEW', { createNew: false })).toThrow(
     `Invalid property path: b.inner3.missing\nCouldn't access "missing" in ${JSON.stringify(
-      testObj1
+      testObj1_original
     )}`
   )
+  // Ensure original hasn't been modified
+  expect(testObj1).toStrictEqual(testObj1_original)
 })
 
 test('Throw error with missing early property', () => {
-  expect(() => assign(cloneDeep(testObj1), 'b.nope', 'NEW', { createNew: false })).toThrow(
-    `Invalid property path: b.nope\nCouldn't access "nope" in ${JSON.stringify(testObj1)}`
+  expect(() => assign(testObj1, 'b.nope', 'NEW', { createNew: false })).toThrow(
+    `Invalid property path: b.nope\nCouldn't access "nope" in ${JSON.stringify(testObj1_original)}`
   )
+  // Ensure original hasn't been modified
+  expect(testObj1).toStrictEqual(testObj1_original)
 })
 
 test('Create new property with missing final property', () => {
-  expect(assign(cloneDeep(testObj1), 'b.inner3.missing', 'Bob', { createNew: true })).toStrictEqual(
-    {
-      ...testObj1,
-      b: { ...testObj1.b, inner3: { ...testObj1.b.inner3, missing: 'Bob' } },
-    }
-  )
+  expect(assign(testObj1, 'b.inner3.missing', 'Bob', { createNew: true })).toStrictEqual({
+    ...testObj1_original,
+    b: { ...testObj1_original.b, inner3: { ...testObj1_original.b.inner3, missing: 'Bob' } },
+  })
+  // Ensure original hasn't been modified
+  expect(testObj1).toStrictEqual(testObj1_original)
 })
 
 // Create or replace properties
 test('Create new property with missing early property', () => {
-  expect(assign(cloneDeep(testObj1), 'x', 'More XXX', { createNew: true })).toStrictEqual({
-    ...testObj1,
+  expect(assign(testObj1, 'x', 'More XXX', { createNew: true })).toStrictEqual({
+    ...testObj1_original,
     x: 'More XXX',
   })
+  // Ensure original hasn't been modified
+  expect(testObj1).toStrictEqual(testObj1_original)
 })
 
 test('Create new property with missing early property with additional path parts', () => {
-  expect(assign(cloneDeep(testObj1), 'x.one.two', 'This is deep')).toStrictEqual({
-    ...testObj1,
+  expect(assign(testObj1, 'x.one.two', 'This is deep')).toStrictEqual({
+    ...testObj1_original,
     x: { one: { two: 'This is deep' } },
   })
+  // Ensure original hasn't been modified
+  expect(testObj1).toStrictEqual(testObj1_original)
 })
 
 test('Create new property in array objects (one exists)', () => {
-  expect(assign(cloneDeep(testObj1), 'b.inner3.innerArray.five', 666)).toStrictEqual({
-    ...testObj1,
+  expect(assign(testObj1, 'b.inner3.innerArray.five', 666)).toStrictEqual({
+    ...testObj1_original,
     b: {
-      ...testObj1.b,
+      ...testObj1_original.b,
       inner3: {
-        ...testObj1.b.inner3,
+        ...testObj1_original.b.inner3,
         innerArray: [
           { one: 1, two: 'two', three: true, four: null, five: 666 },
           { one: 'one', two: 2, three: 3, four: { one: 1 }, five: 666 },
@@ -304,61 +368,75 @@ test('Create new property in array objects (one exists)', () => {
       },
     },
   })
+  // Ensure original hasn't been modified
+  expect(testObj1).toStrictEqual(testObj1_original)
 })
 
 test('Replace simple property with a deeper object', () => {
-  expect(assign(cloneDeep(testObj1), 'a.one.two', 'This is deep')).toStrictEqual({
-    ...testObj1,
+  expect(assign(testObj1, 'a.one.two', 'This is deep')).toStrictEqual({
+    ...testObj1_original,
     a: { one: { two: 'This is deep' } },
   })
+  // Ensure original hasn't been modified
+  expect(testObj1).toStrictEqual(testObj1_original)
 })
 
 // DON'T create new properties (but don't throw error)
 test("Don't create new early property", () => {
-  expect(
-    assign(cloneDeep(testObj1), 'x', 'More XXX', { createNew: false, noError: true })
-  ).toStrictEqual(testObj1)
+  expect(assign(testObj1, 'x', 'More XXX', { createNew: false, noError: true })).toStrictEqual(
+    testObj1_original
+  )
+  // Ensure original hasn't been modified
+  expect(testObj1).toStrictEqual(testObj1_original)
 })
 
 test("Don't create new missing early property with additional path parts", () => {
   expect(
-    assign(cloneDeep(testObj1), 'x.one.two', 'This is deep', { createNew: false, noError: true })
-  ).toStrictEqual(testObj1)
+    assign(testObj1, 'x.one.two', 'This is deep', { createNew: false, noError: true })
+  ).toStrictEqual(testObj1_original)
+  // Ensure original hasn't been modified
+  expect(testObj1).toStrictEqual(testObj1_original)
 })
 
 test("Don't replace simple property with a deeper object", () => {
   expect(
-    assign(cloneDeep(testObj1), 'a.one.two', 'This is deep', { createNew: false, noError: true })
-  ).toStrictEqual(testObj1)
+    assign(testObj1, 'a.one.two', 'This is deep', { createNew: false, noError: true })
+  ).toStrictEqual(testObj1_original)
+  // Ensure original hasn't been modified
+  expect(testObj1).toStrictEqual(testObj1_original)
 })
 
 // Remove properties using "remove" parameter
 test('Remove early property', () => {
-  const t = { ...testObj2 }
+  const t = cloneDeep(testObj2)
   delete t.a
-  expect(assign(cloneDeep(testObj2), 'a', null, { remove: true })).toStrictEqual(t)
+  expect(assign(testObj2, 'a', null, { remove: true })).toStrictEqual(t)
+  // Ensure original hasn't been modified
+  expect(testObj2).toStrictEqual(testObj2_original)
 })
 
 test('Remove deeper property', () => {
   const t = cloneDeep(testObj2)
   delete t.b.inner3.innerDeep2
-  expect(assign(cloneDeep(testObj2), 'b.inner3.innerDeep2', null, { remove: true })).toStrictEqual(
-    t
-  )
+  expect(assign(testObj2, 'b.inner3.innerDeep2', null, { remove: true })).toStrictEqual(t)
+  // Ensure original hasn't been modified
+  expect(testObj2).toStrictEqual(testObj2_original)
 })
 
 test('Remove an array item by index', () => {
   const t = cloneDeep(testObj2)
   t.b.inner3.innerDeep2 = [1, 3]
-  expect(
-    assign(cloneDeep(testObj2), 'b.inner3.innerDeep2[1]', null, { remove: true })
-  ).toStrictEqual(t)
+  expect(assign(testObj2, 'b.inner3.innerDeep2[1]', null, { remove: true })).toStrictEqual(t)
+  // Ensure original hasn't been modified
+  expect(testObj2).toStrictEqual(testObj2_original)
 })
 
 test('Remove a top-level array item by index', () => {
-  const t = { ...testObj2 }
+  const t = cloneDeep(testObj2)
   t.ee = [1, 'two', { three: 4 }, false, undefined]
-  expect(assign(cloneDeep(testObj2), 'ee[5]', null, { remove: true })).toStrictEqual(t)
+  expect(assign(testObj2, 'ee[5]', null, { remove: true })).toStrictEqual(t)
+  // Ensure original hasn't been modified
+  expect(testObj2).toStrictEqual(testObj2_original)
 })
 
 test('Remove an array item when root object is an array', () => {
@@ -371,30 +449,147 @@ test('Remove an array item when root object is an array', () => {
 
 test('Remove top-level array item when root object is an array', () => {
   const t = [1, 2, 3, 4, 5, 6, 7, 8, 9]
-  expect(assign(cloneDeep(t), '[1]', null, { remove: true })).toStrictEqual([
-    1, 3, 4, 5, 6, 7, 8, 9,
-  ])
+  const t_orig = cloneDeep(t)
+  expect(assign(t, '[1]', null, { remove: true })).toStrictEqual([1, 3, 4, 5, 6, 7, 8, 9])
+  // Ensure original hasn't been modified
+  expect(t).toStrictEqual(t_orig)
 })
 
 // Empty property strings
 test('Empty property string (does nothing)', () => {
-  expect(assign(cloneDeep(testObj1), '', 'ALT?')).toStrictEqual(testObj1)
+  expect(assign(testObj1, '', 'ALT?')).toStrictEqual(testObj1)
 })
 
 test('Empty property string after .', () => {
-  expect(assign(cloneDeep(testObj1), 'b.inner3.', 'REPLACED')).toStrictEqual({
-    ...testObj1,
-    b: { ...testObj1.b, inner3: 'REPLACED' },
+  expect(assign(testObj1, 'b.inner3.', 'REPLACED')).toStrictEqual({
+    ...testObj1_original,
+    b: { ...testObj1_original.b, inner3: 'REPLACED' },
   })
+  // Ensure original hasn't been modified
+  expect(testObj1).toStrictEqual(testObj1_original)
 })
 
 // Functions
 test('Add a function', () => {
-  const obj = assign(cloneDeep(testObj1), 'b.newFun', (a: string) => a + 'output')
+  const obj = assign(testObj1, 'b.newFun', (a: string) => a + 'output')
   expect((obj as any)?.b?.newFun('NEW ')).toBe('NEW output')
+  // Ensure original hasn't been modified
+  expect(testObj1).toStrictEqual(testObj1_original)
 })
 
 test('Replace a function', () => {
-  const obj = assign(cloneDeep(testObj1), 'fun', (a: string) => a + 'output')
+  const obj = assign(testObj1, 'fun', (a: string) => a + 'output')
   expect((obj as any).fun('NEW ')).toBe('NEW output')
+  // Ensure original hasn't been modified
+  expect(testObj1).toStrictEqual(testObj1_original)
+})
+
+// Add to arrays
+test('Add simple element to deep array', () => {
+  expect(assign(testObj1, 'b.inner3.innerArray[2]', 'ADD THIS', { createNew: true })).toStrictEqual(
+    {
+      ...testObj1_original,
+      b: {
+        ...testObj1_original.b,
+        inner3: {
+          ...testObj1_original.b.inner3,
+          innerArray: [
+            { one: 1, two: 'two', three: true, four: null, five: true },
+            { one: 'one', two: 2, three: 3, four: { one: 1 } },
+            'ADD THIS',
+          ],
+        },
+      },
+    }
+  )
+  // Ensure original hasn't been modified
+  expect(testObj1).toStrictEqual(testObj1_original)
+})
+
+test('Add simple element to deep array with excessively high index', () => {
+  expect(
+    assign(testObj1, 'b.inner3.innerArray[999]', 'ADD THIS', { createNew: true })
+  ).toStrictEqual({
+    ...testObj1_original,
+    b: {
+      ...testObj1_original.b,
+      inner3: {
+        ...testObj1_original.b.inner3,
+        innerArray: [
+          { one: 1, two: 'two', three: true, four: null, five: true },
+          { one: 'one', two: 2, three: 3, four: { one: 1 } },
+          'ADD THIS',
+        ],
+      },
+    },
+  })
+  // Ensure original hasn't been modified
+  expect(testObj1).toStrictEqual(testObj1_original)
+})
+
+test('Add element to array with extra properties', () => {
+  expect(
+    JSON.stringify(
+      assign(testObj1, 'b.inner3.innerArray[2].newProperty', 'ADD THIS', { createNew: true })
+    )
+  ).toStrictEqual(
+    JSON.stringify({
+      ...testObj1_original,
+      b: {
+        ...testObj1_original.b,
+        inner3: {
+          ...testObj1_original.b.inner3,
+          innerArray: [
+            { one: 1, two: 'two', three: true, four: null, five: true },
+            { one: 'one', two: 2, three: 3, four: { one: 1 } },
+            { newProperty: 'ADD THIS' },
+          ],
+        },
+      },
+    })
+  )
+  // Ensure original hasn't been modified
+  expect(testObj1).toStrictEqual(testObj1_original)
+})
+
+test('Add element to array with extra array properties', () => {
+  expect(JSON.stringify(assign(testObj1, 'b.inner3.innerArray[2][2]', 'ADD THIS'))).toStrictEqual(
+    JSON.stringify({
+      ...testObj1_original,
+      b: {
+        ...testObj1_original.b,
+        inner3: {
+          ...testObj1_original.b.inner3,
+          innerArray: [
+            { one: 1, two: 'two', three: true, four: null, five: true },
+            { one: 'one', two: 2, three: 3, four: { one: 1 } },
+            ['ADD THIS'],
+          ],
+        },
+      },
+    })
+  )
+  // Ensure original hasn't been modified
+  expect(testObj1).toStrictEqual(testObj1_original)
+})
+
+test('Add array element to object with additional path', () => {
+  expect(assign(arrayObj, '[2].one[6].extra[2].inside', 'ADD THIS')).toStrictEqual([
+    1,
+    2,
+    {
+      one: [{ x: 'Ex', y: 'Why' }, { x: 'XXX', y: 'YYY' }, { extra: [{ inside: 'ADD THIS' }] }],
+    },
+  ])
+  // Ensure original hasn't been modified
+  expect(arrayObj).toStrictEqual(arrayObj_original)
+})
+
+test('Assign with path already split into array', () => {
+  expect(assign(testObj1, ['ee', 2, 'newProp'], 'NEW VALUE')).toStrictEqual({
+    ...testObj1_original,
+    ee: [1, 'two', { three: 4, newProp: 'NEW VALUE' }, false, undefined, null],
+  })
+  // Ensure original hasn't been modified
+  expect(testObj1).toStrictEqual(testObj1_original)
 })


### PR DESCRIPTION
Changed the behaviour to return a new object (recursive shallow copy) rather than mutating in place.

- Also added functionality to create new array elements
- Improved path splitting method to handle sequential array references correctly
- Improve tests to also check that original object is unmodified